### PR TITLE
Add a constructor to provide a preconfigured HTTP client builder

### DIFF
--- a/monitored-httpclient/pom.xml
+++ b/monitored-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>resilient-httpclient</artifactId>
         <groupId>com.github.nhenneaux.resilienthttpclient</groupId>
-        <version>0.1.8</version>
+        <version>0.1.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/HttpClientPool.java
+++ b/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/HttpClientPool.java
@@ -46,9 +46,13 @@ public class HttpClientPool implements AutoCloseable {
             final ServerConfiguration serverConfiguration,
             final KeyStore trustStore
     ) {
+        this(dnsLookupWrapper, scheduledExecutorService, serverConfiguration, trustStore, HttpClient.newBuilder());
+    }
+
+    public HttpClientPool(DnsLookupWrapper dnsLookupWrapper, ScheduledExecutorService scheduledExecutorService, ServerConfiguration serverConfiguration, KeyStore trustStore, HttpClient.Builder builder) {
         this.serverConfiguration = serverConfiguration;
         this.httpClientsCache = new AtomicReference<>();
-        this.singleHostnameClient = new SingleHostHttpClientProvider().buildSingleHostnameHttpClient(serverConfiguration.getHostname(), trustStore);
+        this.singleHostnameClient = new SingleHostHttpClientProvider().buildSingleHostnameHttpClient(serverConfiguration.getHostname(), trustStore, builder);
         this.scheduledExecutorService = scheduledExecutorService;
 
         checkDnsCacheSecurityProperties();

--- a/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClient.java
+++ b/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClient.java
@@ -14,8 +14,6 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.nhenneaux.resilienthttpclient</groupId>
     <artifactId>resilient-httpclient</artifactId>
-    <version>0.1.8</version>
+    <version>0.1.9</version>
     <packaging>pom</packaging>
 
     <name>Resilient Java HTTP client based on java.net.http.HttpClient</name>

--- a/single-host-httpclient/pom.xml
+++ b/single-host-httpclient/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.nhenneaux.resilienthttpclient</groupId>
         <artifactId>resilient-httpclient</artifactId>
-        <version>0.1.8</version>
+        <version>0.1.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
It is needed if you want to customize the TCP connect timeout.