### PR TITLE
Improve logging for health-check failure:

### DIFF
--- a/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClient.java
+++ b/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClient.java
@@ -106,12 +106,16 @@ public class SingleIpHttpClient implements AutoCloseable {
                     .thenApply(HttpResponse::statusCode)
                     .join();
 
-            LOGGER.log(Level.INFO, () -> "Checked health for URI " + healthUri + ", status is `" + statusCode + "` in " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start) + "ms.");
+            LOGGER.log(Level.INFO, () -> "Checked health for URI " + healthUri + ", status is `" + statusCode + "`" + timingLogStatement(start));
             healthy.set(statusCode >= 200 && statusCode <= 499);
         } catch (RuntimeException e) {
-            LOGGER.log(Level.INFO, () -> "Failed to check health for address " + healthUri + ", error is `" + e + "`.");
+            LOGGER.log(Level.WARNING, "Failed to check health for address " + healthUri + ", error is `" + e + "`" + timingLogStatement(start), e);
             healthy.set(false);
         }
+    }
+
+    private String timingLogStatement(long start) {
+        return " in " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start) + "ms.";
     }
 
     public InetAddress getInetAddress() {


### PR DESCRIPTION
1. add timing to see actual timeout (to avoid incomplete logs like "Failed to check health for address https://172.20.151.23:5000/..., error is `java.util.concurrent.CompletionException: java.net.http.HttpConnectTimeoutException: HTTP connect timed out`")
2. change log level to WARN
3. printout stacktrace (otherwise it is just lost)