### PR TITLE
Release discarded HttpClient instances on Java 21 and above

### DIFF
--- a/monitored-httpclient/pom.xml
+++ b/monitored-httpclient/pom.xml
@@ -19,4 +19,115 @@
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <!--
+                    Enforces releases must be built with JDK 21 or newer.
+                -->
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>require-jdk-21-for-release</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipRelease}</skip>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[21,)</version>
+                                    <message>Releases must be built with JDK 21 or newer, otherwise
+                                        META-INF/versions/21 is missing from the artifact.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <!--
+                Compiles the Java 21+ HttpClientDisposer into META-INF/versions/21. Activated by the
+                build JDK because javac 11 and 17 cannot compile release 21 and the CI matrix builds
+                with those. Releases must therefore use a JDK 21 or newer; enforced above.
+            -->
+            <id>multi-release</id>
+            <activation>
+                <jdk>[21,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>compile-java-21</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <release>21</release>
+                                    <multiReleaseOutput>true</multiReleaseOutput>
+                                    <compileSourceRoots>
+                                        <compileSourceRoot>${project.basedir}/src/main/java21</compileSourceRoot>
+                                    </compileSourceRoots>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Multi-Release>true</Multi-Release>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <!--
+                            Runs HttpClientDisposerJava21IT against the packaged jar, where
+                            multi-release resolution applies.
+                        -->
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <!--
+                            JaCoCo refuses two class files with the same name, which is what
+                            a multi-release layout is.
+                        -->
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <configuration>
+                                    <excludes>
+                                        <exclude>META-INF/versions/**</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/HttpClientDisposer.java
+++ b/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/HttpClientDisposer.java
@@ -1,0 +1,24 @@
+package com.github.nhenneaux.resilienthttpclient.monitoredclientpool;
+
+import java.net.http.HttpClient;
+import java.util.Objects;
+
+/**
+ * Releases an {@link HttpClient} the pool no longer uses.
+ *
+ * <p>Before Java 21 {@link HttpClient} has no lifecycle method, so only the garbage collector can
+ * reclaim it, and the client keeps its {@code SelectorManager} thread until then.
+ */
+final class HttpClientDisposer {
+    private HttpClientDisposer() {
+    }
+
+    /**
+     * @return whether the client was released, {@code false} below Java 21
+     */
+    public static boolean dispose(HttpClient httpClient) {
+        Objects.requireNonNull(httpClient);
+        // Nothing to call before Java 21.
+        return false;
+    }
+}

--- a/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/ResilientClient.java
+++ b/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/ResilientClient.java
@@ -98,8 +98,10 @@ class ResilientClient extends HttpClient {
             SingleIpHttpClient firstClient,
             List<InetAddress> triedAddress
     ) {
-        final long healthyNodes = roundRobinPool.getList().stream().filter(SingleIpHttpClient::isHealthy).count();
-        if (triedAddress.size() >= healthyNodes) {
+        final boolean everyHealthyClientTried = roundRobinPool.getList().stream()
+                .filter(SingleIpHttpClient::isHealthy)
+                .allMatch(singleIpHttpClient -> triedAddress.contains(singleIpHttpClient.getInetAddress()));
+        if (everyHealthyClientTried) {
             final CompletableFuture<HttpResponse<T>> httpResponseCompletableFuture = new CompletableFuture<>();
             httpResponseCompletableFuture.completeExceptionally(new HttpConnectTimeoutException("Cannot connect to the server, the following address were tried without success " + triedAddress + "."));
             return httpResponseCompletableFuture;
@@ -133,6 +135,10 @@ class ResilientClient extends HttpClient {
                         return handleConnectTimeout(send, roundRobinPool, firstClient, triedAddress).join();
                     }
 
+                    if (wasDisposedWhileHandedOut(throwable, clientWithResponseFuture.singleIpHttpClient)) {
+                        return handleConnectTimeout(send, roundRobinPool, firstClient, triedAddress).join();
+                    }
+
                     if (throwable instanceof Error) {
                         throw (Error) throwable;
                     }
@@ -143,6 +149,11 @@ class ResilientClient extends HttpClient {
                 });
 
         return clientWithResponseFuture.withResponseFuture(httpResponseCompletableFuture);
+    }
+
+    private static boolean wasDisposedWhileHandedOut(final Throwable throwable, final SingleIpHttpClient singleIpHttpClient) {
+        return singleIpHttpClient.isClosed()
+                && (throwable instanceof IOException || throwable.getCause() instanceof IOException);
     }
 
     private static <T> CompletableFuture<HttpResponse<T>> addCounterRefresherFuture(final ClientWithResponseFuture<T> clientWithResponseFuture) {
@@ -188,6 +199,12 @@ class ResilientClient extends HttpClient {
                     throw httpConnectTimeoutException;
                 }
                 client = nextClient.get();
+            } catch (IOException e) {
+                if (!wasDisposedWhileHandedOut(e, client)) {
+                    throw e;
+                }
+                // The request was attempted on a client that was already disposed, send it with another client
+                client = roundRobinPool.next().orElseThrow(() -> e);
             }
         }
         throw new HttpConnectTimeoutException("Cannot connect to the HTTP server, tried to connect to the following IP " + tried + " to send the HTTP request " + request);

--- a/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/ResilientClient.java
+++ b/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/ResilientClient.java
@@ -16,6 +16,7 @@ import java.net.http.HttpResponse;
 import java.net.http.WebSocket;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -47,7 +48,7 @@ class ResilientClient extends HttpClient {
 
     static <T> CompletableFuture<HttpResponse<T>> handleConnectTimeout(Function<HttpClient, CompletableFuture<HttpResponse<T>>> send, RoundRobinPool roundRobinPool) {
         final SingleIpHttpClient firstClient = singleIpHttpClient(roundRobinPool);
-        return handleConnectTimeout(send, roundRobinPool, firstClient, new ArrayList<>());
+        return handleConnectTimeout(send, roundRobinPool, firstClient, new LinkedHashSet<>());
 
     }
 
@@ -96,11 +97,12 @@ class ResilientClient extends HttpClient {
             Function<HttpClient, CompletableFuture<HttpResponse<T>>> send,
             RoundRobinPool roundRobinPool,
             SingleIpHttpClient firstClient,
-            List<InetAddress> triedAddress
+            Set<InetAddress> triedAddress
     ) {
         final boolean everyHealthyClientTried = roundRobinPool.getList().stream()
                 .filter(SingleIpHttpClient::isHealthy)
-                .allMatch(singleIpHttpClient -> triedAddress.contains(singleIpHttpClient.getInetAddress()));
+                .map(SingleIpHttpClient::getInetAddress)
+                .allMatch(triedAddress::contains);
         if (everyHealthyClientTried) {
             final CompletableFuture<HttpResponse<T>> httpResponseCompletableFuture = new CompletableFuture<>();
             httpResponseCompletableFuture.completeExceptionally(new HttpConnectTimeoutException("Cannot connect to the server, the following address were tried without success " + triedAddress + "."));
@@ -122,7 +124,7 @@ class ResilientClient extends HttpClient {
     private static <T> ClientWithResponseFuture<T> addExceptionHandlerFuture(final Function<HttpClient, CompletableFuture<HttpResponse<T>>> send,
                                                                              final RoundRobinPool roundRobinPool,
                                                                              final SingleIpHttpClient firstClient,
-                                                                             final List<InetAddress> triedAddress,
+                                                                             final Set<InetAddress> triedAddress,
                                                                              final ClientWithResponseFuture<T> clientWithResponseFuture) {
 
         final CompletableFuture<HttpResponse<T>> httpResponseCompletableFuture = clientWithResponseFuture.httpResponseFuture
@@ -152,7 +154,7 @@ class ResilientClient extends HttpClient {
     }
 
     private static boolean wasDisposedWhileHandedOut(final Throwable throwable, final SingleIpHttpClient singleIpHttpClient) {
-        return singleIpHttpClient.isClosed()
+        return singleIpHttpClient.isClosing()
                 && (throwable instanceof IOException || throwable.getCause() instanceof IOException);
     }
 

--- a/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClient.java
+++ b/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClient.java
@@ -34,7 +34,7 @@ public class SingleIpHttpClient implements AutoCloseable {
     private final Future<?> scheduledFuture;
     private final ServerConfiguration serverConfiguration;
     private final AtomicInteger failedResponseCount;
-    private final AtomicBoolean closed = new AtomicBoolean();
+    private final AtomicBoolean closing = new AtomicBoolean();
 
     /**
      * Create a new instance of the client and schedule a task to refresh is healthiness.
@@ -99,10 +99,10 @@ public class SingleIpHttpClient implements AutoCloseable {
 
     /**
      * If called and the previous health status was unhealthy, then a new health check is performed.
-     * A closed client is never healthy again.
+     * A client whose close has been initiated is never healthy again.
      */
     public boolean isHealthy() {
-        if (closed.get()) {
+        if (closing.get()) {
             return false;
         }
         if (!healthy.get()) {
@@ -112,10 +112,10 @@ public class SingleIpHttpClient implements AutoCloseable {
     }
 
     /**
-     * @return whether {@link #close()} was called, in which case the underlying client rejects new requests
+     * @return whether {@link #close()} was initiated, in which case the underlying client rejects new requests
      */
-    boolean isClosed() {
-        return closed.get();
+    boolean isClosing() {
+        return closing.get();
     }
 
     /**
@@ -213,7 +213,7 @@ public class SingleIpHttpClient implements AutoCloseable {
 
     @Override
     public void close() {
-        closed.set(true);
+        closing.set(true);
         scheduledFuture.cancel(true);
         HttpClientDisposer.dispose(httpClient);
     }

--- a/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClient.java
+++ b/monitored-httpclient/src/main/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClient.java
@@ -34,6 +34,7 @@ public class SingleIpHttpClient implements AutoCloseable {
     private final Future<?> scheduledFuture;
     private final ServerConfiguration serverConfiguration;
     private final AtomicInteger failedResponseCount;
+    private final AtomicBoolean closed = new AtomicBoolean();
 
     /**
      * Create a new instance of the client and schedule a task to refresh is healthiness.
@@ -98,12 +99,23 @@ public class SingleIpHttpClient implements AutoCloseable {
 
     /**
      * If called and the previous health status was unhealthy, then a new health check is performed.
+     * A closed client is never healthy again.
      */
     public boolean isHealthy() {
+        if (closed.get()) {
+            return false;
+        }
         if (!healthy.get()) {
             checkHealthStatus();
         }
         return healthy.get();
+    }
+
+    /**
+     * @return whether {@link #close()} was called, in which case the underlying client rejects new requests
+     */
+    boolean isClosed() {
+        return closed.get();
     }
 
     /**
@@ -201,7 +213,9 @@ public class SingleIpHttpClient implements AutoCloseable {
 
     @Override
     public void close() {
+        closed.set(true);
         scheduledFuture.cancel(true);
+        HttpClientDisposer.dispose(httpClient);
     }
 
 }

--- a/monitored-httpclient/src/main/java21/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/HttpClientDisposer.java
+++ b/monitored-httpclient/src/main/java21/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/HttpClientDisposer.java
@@ -1,0 +1,20 @@
+package com.github.nhenneaux.resilienthttpclient.monitoredclientpool;
+
+import java.net.http.HttpClient;
+
+/**
+ * Java 21 and above variant of {@code HttpClientDisposer}
+ */
+final class HttpClientDisposer {
+    private HttpClientDisposer() {
+    }
+
+    /**
+     * @return always {@code true}, the client is released
+     */
+    public static boolean dispose(HttpClient httpClient) {
+        // Graceful and non-blocking. Not close(), which blocks until every exchange completes.
+        httpClient.shutdown();
+        return true;
+    }
+}

--- a/monitored-httpclient/src/test/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/HttpClientDisposerJava21IT.java
+++ b/monitored-httpclient/src/test/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/HttpClientDisposerJava21IT.java
@@ -1,0 +1,15 @@
+package com.github.nhenneaux.resilienthttpclient.monitoredclientpool;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class HttpClientDisposerJava21IT {
+    @Test
+    void shouldReleaseTheClient() {
+        assertThat(HttpClientDisposer.dispose(HttpClient.newHttpClient()), equalTo(true));
+    }
+}

--- a/monitored-httpclient/src/test/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/HttpClientDisposerTest.java
+++ b/monitored-httpclient/src/test/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/HttpClientDisposerTest.java
@@ -1,0 +1,59 @@
+package com.github.nhenneaux.resilienthttpclient.monitoredclientpool;
+
+import com.github.nhenneaux.resilienthttpclient.singlehostclient.ServerConfiguration;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Surefire's classpath is a directory, so {@code META-INF/versions/21} is never consulted and the
+ * baseline variant is always the one loaded. The Java 21+ variant is a single {@code shutdown()}
+ * call, compiled by the CI matrix on JDK 21, 25 and 26.
+ */
+class HttpClientDisposerTest {
+
+    @Test
+    void shouldRejectNullClient() {
+        assertThrows(NullPointerException.class, () -> HttpClientDisposer.dispose(null));
+    }
+
+    @Test
+    void baselineShouldReportTheClientWasNotReleased() {
+        assertFalse(HttpClientDisposer.dispose(mock(HttpClient.class)));
+    }
+
+    @Test
+    void closeShouldDisposeTheUnderlyingClient() throws UnknownHostException {
+        // Given
+        final HttpClient httpClient = healthyClient();
+        final SingleIpHttpClient singleIpHttpClient = new SingleIpHttpClient(httpClient, InetAddress.getByName("127.0.0.1"), new ServerConfiguration("localhost"));
+
+        try (MockedStatic<HttpClientDisposer> disposer = mockStatic(HttpClientDisposer.class)) {
+            // When
+            singleIpHttpClient.close();
+
+            // Then
+            disposer.verify(() -> HttpClientDisposer.dispose(httpClient));
+        }
+    }
+
+    private static HttpClient healthyClient() {
+        final HttpClient httpClient = mock(HttpClient.class);
+        final HttpResponse<Void> httpResponse = mock();
+        doReturn(200).when(httpResponse).statusCode();
+        doReturn(CompletableFuture.completedFuture(httpResponse)).when(httpClient).sendAsync(any(), any());
+        return httpClient;
+    }
+}

--- a/monitored-httpclient/src/test/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/ResilientClientTest.java
+++ b/monitored-httpclient/src/test/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/ResilientClientTest.java
@@ -23,13 +23,20 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -479,5 +486,211 @@ class ResilientClientTest {
                     .mapToInt(SingleIpHttpClient::getFailedResponseCount)
                     .sum(), equalTo(1));
         }
+    }
+
+    @Test
+    void shouldSendToAnotherClientWhenTheOneHandedOutIsDisposed() throws IOException, InterruptedException {
+        // Given
+        final HttpRequest httpRequest = junitRequest();
+        final HttpResponse.BodyHandler<Void> bodyHandler = HttpResponse.BodyHandlers.discarding();
+
+        final AtomicReference<SingleIpHttpClient> disposed = new AtomicReference<>();
+        final HttpClient disposedHttpClient = healthyHttpClient();
+        doAnswer(invocation -> {
+            // the pool refreshes and disposes the client between the round robin handing it out and the send
+            disposed.get().close();
+            throw new IOException("closed");
+        }).when(disposedHttpClient).send(httpRequest, bodyHandler);
+
+        final HttpClient survivingHttpClient = healthyHttpClient();
+        @SuppressWarnings("unchecked") final HttpResponse<Void> okResponse = mock(HttpResponse.class);
+        when(okResponse.statusCode()).thenReturn(200);
+        when(survivingHttpClient.send(httpRequest, bodyHandler)).thenReturn(okResponse);
+
+        disposed.set(singleIpHttpClient(disposedHttpClient, getInetAddress()));
+        final SingleIpHttpClient surviving = singleIpHttpClient(survivingHttpClient, InetAddress.getLoopbackAddress());
+        final RoundRobinPool roundRobinPool = new RoundRobinPool(List.of(disposed.get(), surviving));
+
+        // When
+        final HttpResponse<Void> httpResponse = new ResilientClient(() -> roundRobinPool).send(httpRequest, bodyHandler);
+
+        // Then
+        assertSame(okResponse, httpResponse);
+        assertThat("the disposal is ours, not a server failure", disposed.get().getFailedResponseCount(), equalTo(0));
+    }
+
+    @Test
+    void shouldSendAsyncToAnotherClientWhenTheOneHandedOutIsDisposed() throws ExecutionException, InterruptedException {
+        // Given
+        final HttpRequest httpRequest = junitRequest();
+        final HttpResponse.BodyHandler<Void> bodyHandler = HttpResponse.BodyHandlers.discarding();
+
+        final AtomicReference<SingleIpHttpClient> disposed = new AtomicReference<>();
+        final HttpClient disposedHttpClient = healthyHttpClient();
+        doAnswer(invocation -> {
+            disposed.get().close();
+            return CompletableFuture.failedFuture(new IOException("closed"));
+        }).when(disposedHttpClient).sendAsync(eq(httpRequest), any());
+
+        final HttpClient survivingHttpClient = healthyHttpClient();
+        @SuppressWarnings("unchecked") final HttpResponse<Void> okResponse = mock(HttpResponse.class);
+        when(okResponse.statusCode()).thenReturn(200);
+        doReturn(CompletableFuture.completedFuture(okResponse)).when(survivingHttpClient).sendAsync(eq(httpRequest), any());
+
+        disposed.set(singleIpHttpClient(disposedHttpClient, getInetAddress()));
+        final SingleIpHttpClient surviving = singleIpHttpClient(survivingHttpClient, InetAddress.getLoopbackAddress());
+        final RoundRobinPool roundRobinPool = new RoundRobinPool(List.of(disposed.get(), surviving));
+
+        // When
+        final CompletableFuture<HttpResponse<Void>> httpResponse = new ResilientClient(() -> roundRobinPool).sendAsync(httpRequest, bodyHandler);
+
+        // Then
+        assertSame(okResponse, httpResponse.get());
+        assertThat("the disposal is ours, not a server failure", disposed.get().getFailedResponseCount(), equalTo(0));
+    }
+
+    @Test
+    void shouldNotRetryWhenTheClientHandedOutIsStillInThePool() throws IOException, InterruptedException {
+        // Given
+        final HttpRequest httpRequest = junitRequest();
+        final HttpResponse.BodyHandler<Void> bodyHandler = HttpResponse.BodyHandlers.discarding();
+
+        final HttpClient failingHttpClient = healthyHttpClient();
+        doThrow(new IOException("boom")).when(failingHttpClient).send(httpRequest, bodyHandler);
+        final HttpClient otherHttpClient = healthyHttpClient();
+
+        final RoundRobinPool roundRobinPool = new RoundRobinPool(List.of(
+                singleIpHttpClient(failingHttpClient, getInetAddress()),
+                singleIpHttpClient(otherHttpClient, InetAddress.getLoopbackAddress())));
+
+        // When
+        final IOException ioException = assertThrows(IOException.class, () -> new ResilientClient(() -> roundRobinPool).send(httpRequest, bodyHandler));
+
+        // Then
+        assertEquals("boom", ioException.getMessage());
+        verify(otherHttpClient, never()).send(httpRequest, bodyHandler);
+    }
+
+    @Test
+    void shouldFailWhenTheOnlyClientIsDisposedWhileHandedOut() throws IOException, InterruptedException {
+        // Given
+        final HttpRequest httpRequest = junitRequest();
+        final HttpResponse.BodyHandler<Void> bodyHandler = HttpResponse.BodyHandlers.discarding();
+
+        final AtomicReference<SingleIpHttpClient> disposed = new AtomicReference<>();
+        final HttpClient disposedHttpClient = healthyHttpClient();
+        doAnswer(invocation -> {
+            disposed.get().close();
+            throw new IOException("closed");
+        }).when(disposedHttpClient).send(httpRequest, bodyHandler);
+
+        disposed.set(singleIpHttpClient(disposedHttpClient, getInetAddress()));
+        final RoundRobinPool roundRobinPool = new RoundRobinPool(List.of(disposed.get()));
+
+        // When
+        final IOException ioException = assertThrows(IOException.class, () -> new ResilientClient(() -> roundRobinPool).send(httpRequest, bodyHandler));
+
+        // Then
+        assertEquals("closed", ioException.getMessage());
+    }
+
+    @Test
+    void shouldFailAsyncWhenTheOnlyClientIsDisposedWhileHandedOut() {
+        // Given
+        final HttpRequest httpRequest = junitRequest();
+        final HttpResponse.BodyHandler<Void> bodyHandler = HttpResponse.BodyHandlers.discarding();
+
+        final AtomicReference<SingleIpHttpClient> disposed = new AtomicReference<>();
+        final HttpClient disposedHttpClient = healthyHttpClient();
+        doAnswer(invocation -> {
+            disposed.get().close();
+            return CompletableFuture.failedFuture(new IOException("closed"));
+        }).when(disposedHttpClient).sendAsync(eq(httpRequest), any());
+
+        disposed.set(singleIpHttpClient(disposedHttpClient, getInetAddress()));
+        final RoundRobinPool roundRobinPool = new RoundRobinPool(List.of(disposed.get()));
+
+        // When
+        final CompletableFuture<HttpResponse<Void>> httpResponse = new ResilientClient(() -> roundRobinPool).sendAsync(httpRequest, bodyHandler);
+
+        // Then
+        final ExecutionException executionException = assertThrows(ExecutionException.class, httpResponse::get);
+        assertThat(executionException.getCause(), instanceOf(HttpConnectTimeoutException.class));
+    }
+
+    @Test
+    void shouldNotRetryWhenADisposedClientFailedAfterTheRequestWasSent() {
+        // Given
+        final HttpRequest httpRequest = junitRequest();
+        final HttpResponse.BodyHandler<Void> bodyHandler = HttpResponse.BodyHandlers.discarding();
+
+        final AtomicReference<SingleIpHttpClient> disposed = new AtomicReference<>();
+        final HttpClient disposedHttpClient = healthyHttpClient();
+        doAnswer(invocation -> {
+            // The response came back, so the request did reach the server, and the body handler failed on it
+            disposed.get().close();
+            return CompletableFuture.failedFuture(new IllegalStateException("invalid body"));
+        }).when(disposedHttpClient).sendAsync(eq(httpRequest), any());
+
+        final HttpClient otherHttpClient = healthyHttpClient();
+
+        disposed.set(singleIpHttpClient(disposedHttpClient, getInetAddress()));
+        final RoundRobinPool roundRobinPool = new RoundRobinPool(List.of(disposed.get(), singleIpHttpClient(otherHttpClient, InetAddress.getLoopbackAddress())));
+
+        // When
+        final CompletableFuture<HttpResponse<Void>> httpResponse = new ResilientClient(() -> roundRobinPool).sendAsync(httpRequest, bodyHandler);
+
+        // Then
+        final ExecutionException executionException = assertThrows(ExecutionException.class, httpResponse::get);
+        assertThat(executionException.getCause(), instanceOf(IllegalStateException.class));
+        verify(otherHttpClient, never()).sendAsync(eq(httpRequest), any());
+    }
+
+    @Test
+    void shouldTryTheOtherClientWhenTheFirstOneGoesDownWhileConnecting() {
+        // Given
+        final HttpRequest httpRequest = junitRequest();
+        final HttpResponse.BodyHandler<Void> bodyHandler = HttpResponse.BodyHandlers.discarding();
+
+        final HttpClient downHttpClient = mock(HttpClient.class);
+        @SuppressWarnings("unchecked") final HttpResponse<Void> healthResponse = mock(HttpResponse.class);
+        when(healthResponse.statusCode()).thenReturn(200, 500);
+        doReturn(CompletableFuture.completedFuture(healthResponse)).when(downHttpClient).sendAsync(any(), any());
+        final SingleIpHttpClient down = singleIpHttpClient(downHttpClient, getInetAddress());
+
+        doAnswer(invocation -> {
+            // The node is down, so the scheduled health check sees it too
+            down.checkHealthStatus();
+            return CompletableFuture.failedFuture(new CompletionException(new ConnectException("connection refused")));
+        }).when(downHttpClient).sendAsync(eq(httpRequest), any());
+
+        final HttpClient upHttpClient = healthyHttpClient();
+        @SuppressWarnings("unchecked") final HttpResponse<Void> okResponse = mock(HttpResponse.class);
+        when(okResponse.statusCode()).thenReturn(200);
+        doReturn(CompletableFuture.completedFuture(okResponse)).when(upHttpClient).sendAsync(eq(httpRequest), any());
+
+        final RoundRobinPool roundRobinPool = new RoundRobinPool(List.of(down, singleIpHttpClient(upHttpClient, InetAddress.getLoopbackAddress())));
+
+        // When
+        final CompletableFuture<HttpResponse<Void>> httpResponse = new ResilientClient(() -> roundRobinPool).sendAsync(httpRequest, bodyHandler);
+
+        // Then
+        assertSame(okResponse, httpResponse.join());
+    }
+
+    private static HttpRequest junitRequest() {
+        return HttpRequest.newBuilder().uri(URI.create("https://com.github.nhenneaux.resilienthttpclient.singlehostclient.ResilientClientTest.junit")).build();
+    }
+
+    private static SingleIpHttpClient singleIpHttpClient(final HttpClient httpClient, final InetAddress inetAddress) {
+        return new SingleIpHttpClient(httpClient, inetAddress, new ServerConfiguration(UUID.randomUUID().toString()));
+    }
+
+    private static HttpClient healthyHttpClient() {
+        final HttpClient httpClient = mock(HttpClient.class);
+        @SuppressWarnings("unchecked") final HttpResponse<Void> healthResponse = mock(HttpResponse.class);
+        when(healthResponse.statusCode()).thenReturn(200);
+        doReturn(CompletableFuture.completedFuture(healthResponse)).when(httpClient).sendAsync(any(), any());
+        return httpClient;
     }
 }

--- a/monitored-httpclient/src/test/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClientTest.java
+++ b/monitored-httpclient/src/test/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClientTest.java
@@ -67,6 +67,23 @@ class SingleIpHttpClientTest {
     }
 
     @Test
+    void shouldNotBeHealthyOnceClosed() {
+        // Given
+        final String hostname = oneHostname();
+        final HttpClient httpClient = mock(HttpClient.class);
+        @SuppressWarnings("unchecked") final HttpResponse<Void> httpResponse = mock(HttpResponse.class);
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpClient.sendAsync(any(HttpRequest.class), any(DISCARDING_BODY_HANDLER_CLASS))).thenReturn(CompletableFuture.completedFuture(httpResponse));
+        final SingleIpHttpClient singleIpHttpClient = new SingleIpHttpClient(httpClient, InetAddress.getLoopbackAddress(), new ServerConfiguration(hostname));
+        assertTrue(singleIpHttpClient.isHealthy());
+        // When
+        singleIpHttpClient.close();
+        // Then
+        assertTrue(singleIpHttpClient.isClosed());
+        assertFalse(singleIpHttpClient.isHealthy(), "the round robin must not hand out a closed client");
+    }
+
+    @Test
     void shouldBeUnHealthyWith500Status() {
         // Given
         final String hostname = oneHostname();

--- a/monitored-httpclient/src/test/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClientTest.java
+++ b/monitored-httpclient/src/test/java/com/github/nhenneaux/resilienthttpclient/monitoredclientpool/SingleIpHttpClientTest.java
@@ -79,7 +79,7 @@ class SingleIpHttpClientTest {
         // When
         singleIpHttpClient.close();
         // Then
-        assertTrue(singleIpHttpClient.isClosed());
+        assertTrue(singleIpHttpClient.isClosing());
         assertFalse(singleIpHttpClient.isHealthy(), "the round robin must not hand out a closed client");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <sonar.organization>nhenneaux</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 


### PR DESCRIPTION
We saw our thread count steadily increase for hours in live test applications, and only reclaimed until we manually performed GC. Investigation lead us to leaking `SelectorManager` threads from the HttpClient created by the `HttpClientPool`.

`SingleIpHttpClient.close()` cancels the health check schedule but never releases the wrapped `java.net.http.HttpClient`. Each client owns a `SelectorManager` thread and a selector file descriptor, and that thread keeps the client implementation reachable while holding only a weak reference to the facade. So a pool that refreshes its clients, on a new DNS address or on a violated failure count threshold, leaves one such thread behind per discarded client until the garbage collector collects it.


`HttpClient` has no lifecycle method before Java 21, so the release is a multi-release override:

| | |
|---|---|
| `src/main/java` | returns `false`, the only thing possible below Java 21 |
| `src/main/java21` | `httpClient.shutdown()`, returns `true` |

`shutdown()` rather than `close()`, which blocks until every exchange completes and would stall the pool's DNS refresh scheduler, and rather than `shutdownNow()`, which would cancel exchanges the round robin already handed out.

Releasing the client makes discarding it observable: `shutdown()` refuses new requests, so a client the round robin handed out just before the pool dropped it would fail the request with `IOException: closed`, which `ResilientClient` does not fail over on. It is refused before it reaches the wire, verified against a local server that counted one request rather than two, so the request can be sent to another client without any risk of sending it twice. `SingleIpHttpClient` therefore tracks whether it was closed, is never healthy again once it is, and both `send` paths move to the next client on an `IOException` from a client we closed ourselves. Any other `IOException` still propagates, and so does any non-`IOException`, which came back with a response and must not be sent twice.

That failover needs the asynchronous path to stop at the right moment, and `triedAddress.size() >= healthyNodes` does not: it compares a tally of addresses against a count that shrinks whenever one of them stops being healthy. This is not specific to the disposal, a node that refuses the connection and fails its health check at the same time already ends the request instead of failing over, which `shouldTryTheOtherClientWhenTheFirstOneGoesDownWhileConnecting` reproduces on the current code. Asking the question directly, whether every healthy client has been tried, fixes both.

`dispose()` returns whether it released the client, so the versioned behaviour is observable through a signature that compiles at the module baseline. `HttpClientDisposerJava21IT` asserts that under Failsafe, which runs against the packaged jar where multi-release resolution applies. 

Build notes:

- The versioned source is compiled by a profile activated on JDK 21 and above, because javac 11 and 17 cannot compile release 21 and the CI matrix builds with those. On those runtimes the baseline is also the only correct behaviour.
- Failsafe is bound in that same profile, since without the versioned class the IT would legitimately fail.
- That makes the artifact depend on the build JDK, so an enforcer rule tied to `skipRelease` fails a release built below JDK 21. It sits outside the profile, which is inactive in exactly the case it has to catch.
- JaCoCo cannot analyse two class files with the same name, so the versioned copy is excluded from the report.
- The root pom now sets `maven.compiler.release` instead of `source`/`target`. The split only works if the baseline really is Java 11 API clean, and `-source 11 -target 11` still compiles against the build JDK's API, so `httpClient.shutdown()` in the baseline variant would have compiled on JDK 21 and failed at runtime on 11. With `release` it is a compile error.